### PR TITLE
Update PORT variable logic

### DIFF
--- a/api/src/utils/config.ts
+++ b/api/src/utils/config.ts
@@ -17,7 +17,11 @@ switch (process.env.ENVIRONMENT.toLowerCase()) {
     production = false;
 }
 
-export default {
-  PORT: process.env.PORT !== undefined ? parseInt(process.env.PORT) : 3000,
-  production
-}
+let PORT: number;
+if (production) {
+  if (process.env.PORT !== undefined) {
+    PORT = parseInt(process.env.PORT);
+  } else PORT = 80;
+} else PORT = 3000;
+
+export default { production, PORT }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "concurrently -n \"Angular,  API  \" -c \"bgGreen.bold,bgCyan.bold\" yarn:dev-ng yarn:dev-api",
     "build": "ng build && tsc --build ./api/tsconfig.json",
-    "start": "cross-env ENVIRONMENT=production PORT=80 node .",
+    "start": "cross-env ENVIRONMENT=production node .",
     "dev-ng": "ng serve --proxy-config proxy.config.json",
     "dev-api": "ts-node-dev -P ./api/tsconfig.json ./api/src/main.ts"
   },


### PR DESCRIPTION
If the app's in development, always use port 3000. This will allow Angular to proxy it.

Otherwise, during production, check if there's a `PORT` environment variable set. If so, use it. Otherwise, use the default port 80.